### PR TITLE
URL変更(ボクにもわかる for MixJuice)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ GET・GETS の違いは一部コンテンツのコマンドで継承します。
 |[15JM.LI/K](https://github.com/fu-sen/15jm.li/blob/master/k)|[Kidspod;](http://kidspod.club/)|Kidspod; ID|対応 ※|
 |[15JM.LI/C](https://github.com/fu-sen/15jm.li/blob/master/c)|[IchigoJam club](https://fukuno.jig.jp/2807)| | |
 |[15JM.LI/P](https://github.com/fu-sen/15jm.li/blob/master/p)|[ichigojam.net プログラムコレクション](https://www.facebook.com/groups/ichigojam/permalink/718281468311609/)| |対応 ※|
-|[15JM.LI/B](https://github.com/fu-sen/15jm.li/blob/master/b)|[ボクにもわかる for MixJuice](https://blogs.yahoo.co.jp/bokunimowakaru/55369582.html)| |対応|
+|[15JM.LI/B](https://github.com/fu-sen/15jm.li/blob/master/b)|[ボクにもわかる for MixJuice](https://bokunimo.net/blog/ichigojam/131/)| |対応|
 |[15JM.LI/I](https://github.com/fu-sen/15jm.li/blob/master/i)|[イチゴジャム レシピ MixJuice コンテンツ 短縮 URL](https://github.com/fu-sen/15j.in)| |対応|
 |[15JM.LI/M](https://github.com/fu-sen/15jm.li/blob/master/m)|[Micono Utilities for MixJuice](http://ijutilities.micutil.com/)| | |
 |[15JM.LI/O](https://github.com/fu-sen/15jm.li/blob/master/o)|[IchigoJamを楽しもう](http://www.openspc2.org/reibun/IchigoJam/)|dir/file| |

--- a/b
+++ b/b
@@ -1,10 +1,10 @@
 <?php
 if (empty($data))
 {
-   echo "?\"MJ {$get} bokunimowakaru.github.io/MJ/\n";
+   echo "?\"MJ {$get} git.bokunimo.com/MJ/\n";
 }
 else
 {
    $page = $data * 100;
-   echo "?\"MJ {$get} bokunimowakaru.github.io/MJ/{$page}.txt\n";
+   echo "?\"MJ {$get} git.bokunimo.com/MJ/{$page}.txt\n";
 }


### PR DESCRIPTION
GitHubに独自ドメインを付けたのですが、MixJuiceが301転送できないように付き、URLの修正をお願いいたします。
また、READMEの当方ブログのURLも合わせて修正しました。
ご承認をいただきたく。